### PR TITLE
Fix significance computation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "kendalls"
 description = "Kendall's tau rank correlation"
-version = "0.1.6"
-authors = ["zolkko <zolkko@gmail.com>"]
+version = "0.2.0"
+authors = [
+	"zolkko <zolkko@gmail.com>",
+	"Genaro Camele <genarocamele@gmail.com>"
+]
 
 include = ["src/**/*.rs", "Cargo.toml"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ description = "Kendall's tau rank correlation"
 version = "0.2.0"
 authors = [
 	"zolkko <zolkko@gmail.com>",
-	"Genaro Camele <genarocamele@gmail.com>"
+	"Genaro Camele <genarocamele@gmail.com>",
+	"Matías Ignacio Caruso"
 ]
 
 include = ["src/**/*.rs", "Cargo.toml"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,17 +256,6 @@ where
     Ok((tau_b.max(-1.0).min(1.0), z))
 }
 
-/// Calculate statistical significance: Z.
-///
-/// Typically any value greater than 1.96 is going to be statistically significant
-/// against the Z-table with alpha set at 0.05.
-pub fn significance(tau: f64, n: usize) -> f64 {
-
-    let n_tmp: f64 = (n * (n - 1)) as f64;
-    let deter: f64 = (2 * (2 * n + 5)) as f64;
-    (3.0 * tau * n_tmp.sqrt()) / deter.sqrt()
-}
-
 #[inline]
 fn sum(n: usize) -> usize {
     n * (n + 1 as usize) / 2 as usize
@@ -389,12 +378,5 @@ mod tests {
     fn it_format_insufficient_length_error() {
         let error = Error::InsufficientLength {} ;
         assert_eq!("insufficient array length", format!("{}", error));
-    }
-
-    #[test]
-    fn significance_computed_correctly_for_certain_values() {
-        let res = significance(0.818, 12);
-        assert!(res > 3.7009);
-        assert!(res < 3.709);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,11 +87,7 @@ where
 
     let n = x.len();
 
-    // TODO: refactor
-    let mut pairs: Vec<(T, T)> = Vec::with_capacity(n);
-    for pair in x.iter().cloned().zip(y.iter().cloned()) {
-        pairs.push(pair);
-    }
+    let mut pairs: Vec<(T, T)> = x.iter().cloned().zip(y.iter().cloned()).collect();
 
     pairs.sort_by(|pair1, pair2| {
         let res = comparator(&pair1.0, &pair2.0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,13 @@
 //! [Kendall's tau rank correlation](https://en.wikipedia.org/wiki/Kendall_rank_correlation_coefficient).
 //! At this point this is basically a copy-paste
 //! from [Apache Commons Math](http://commons.apache.org/proper/commons-math/) library with some
-//! additions taken from [scipy](https://github.com/scipy/scipy).
+//! additions taken from [scipy](https://github.com/scipy/scipy)
+//! and R [cor.test](https://github.com/SurajGupta/r-source/blob/master/src/library/stats/R/cor.test.R) function
 //!
 //! Example usage:
 //! ```
 //! let res = kendalls::tau_b(&[1, 2, 3], &[3, 4, 5]);
-//! assert_eq!(res, Ok(1.0));
+//! assert_eq!(res, Ok((1.0, 1.5666989036012806)));
 //! ```
 //! If you want to compute correlation, let's say, for `f64` type, then you will have to
 //! provide either a custom comparator function or declare `Ord` trait for your custom floating point
@@ -15,12 +16,12 @@
 //! ```
 //! use std::cmp::Ordering;
 //!
-//! let res = kendalls::tau_b_with_comparator(
+//! let (tau_b, _) = kendalls::tau_b_with_comparator(
 //!            &[1.0, 2.0],
 //!            &[3.0, 4.0],
 //!            |a: &f64, b: &f64| a.partial_cmp(&b).unwrap_or(Ordering::Greater),
-//!        );
-//! assert_eq!(res, Ok(1.0));
+//!        ).unwrap();
+//! assert_eq!(tau_b, 1.0);
 //! ```
 //!
 //! The function will return an error if you pass empty arrays into it or `x` and `y` arrays'
@@ -58,7 +59,7 @@ impl StdError for Error {}
 /// where P is the number of concordant pairs, Q the number of discordant pairs, T the number of
 /// ties only in x, and U the number of ties only in y. If a tie occurs for the same pair in
 /// both x and y, it is not added to either T or U.
-pub fn tau_b<T>(x: &[T], y: &[T]) -> Result<f64, Error>
+pub fn tau_b<T>(x: &[T], y: &[T]) -> Result<(f64, f64), Error>
 where
     T: Ord + Clone + Default,
 {
@@ -68,7 +69,7 @@ where
 /// The same as `tau_b` but also allow to specify custom comparator for numbers for
 /// which [Ord] trait is not defined.
 #[allow(clippy::many_single_char_names)]
-pub fn tau_b_with_comparator<T, F>(x: &[T], y: &[T], mut comparator: F) -> Result<f64, Error>
+pub fn tau_b_with_comparator<T, F>(x: &[T], y: &[T], mut comparator: F) -> Result<(f64, f64), Error>
 where
     T: PartialOrd + Clone + Default,
     F: FnMut(&T, &T) -> Ordering,
@@ -86,6 +87,7 @@ where
 
     let n = x.len();
 
+    // TODO: refactor
     let mut pairs: Vec<(T, T)> = Vec::with_capacity(n);
     for pair in x.iter().cloned().zip(y.iter().cloned()) {
         pairs.push(pair);
@@ -100,8 +102,12 @@ where
         }
     });
 
+    let mut v1_part_1 = 0usize;
+    let mut v2_part_1 = 0isize;
+
     let mut tied_x_pairs = 0usize;
     let mut tied_xy_pairs = 0usize;
+    let mut vt = 0usize;
     let mut consecutive_x_ties = 1usize;
     let mut consecutive_xy_ties = 1usize;
 
@@ -117,12 +123,26 @@ where
                 consecutive_xy_ties = 1;
             }
         } else {
+            // TODO: refactor
+            vt += consecutive_x_ties * (consecutive_x_ties - 1) * (2 * consecutive_x_ties + 5);
+            v1_part_1 += consecutive_x_ties * (consecutive_x_ties - 1);
+
+            let consecutive_x_ties_i = consecutive_x_ties as isize;
+            v2_part_1 += consecutive_x_ties_i * (consecutive_x_ties_i - 1) * (consecutive_x_ties_i - 2);
+
             tied_x_pairs += sum(consecutive_x_ties - 1);
             consecutive_x_ties = 1;
             tied_xy_pairs += sum(consecutive_xy_ties - 1);
             consecutive_xy_ties = 1;
+
         }
     }
+
+    vt += consecutive_x_ties * (consecutive_x_ties - 1) * (2 * consecutive_x_ties + 5);
+    v1_part_1 += consecutive_x_ties * (consecutive_x_ties - 1);
+
+    let consecutive_x_ties_i = consecutive_x_ties as isize;
+    v2_part_1 += consecutive_x_ties_i * (consecutive_x_ties_i - 1) * (consecutive_x_ties_i - 2);
 
     tied_x_pairs += sum(consecutive_x_ties - 1);
     tied_xy_pairs += sum(consecutive_xy_ties - 1);
@@ -169,21 +189,40 @@ where
         segment_size <<= 1;
     }
 
+    let mut v1_part_2 = 0usize;
+    let mut v2_part_2 = 0isize;
     let mut tied_y_pairs = 0usize;
     let mut consecutive_y_ties = 1usize;
+    let mut vu = 0usize;
 
-    for i in 1..n {
-        let prev = &pairs[i - 1];
-        let curr = &pairs[i];
+    for j in 1..n {
+        let prev = &pairs[j - 1];
+        let curr = &pairs[j];
         if curr.1 == prev.1 {
             consecutive_y_ties += 1;
         } else {
+            // TODO: refactor
+            vu += consecutive_y_ties * (consecutive_y_ties - 1) * (2 * consecutive_y_ties + 5);
+            v1_part_2 += consecutive_y_ties * (consecutive_y_ties - 1);
+
+            let consecutive_y_ties_i = consecutive_y_ties as isize;
+            v2_part_2 += consecutive_y_ties_i * (consecutive_y_ties_i - 1) * (consecutive_y_ties_i - 2);
+            
             tied_y_pairs += sum(consecutive_y_ties - 1);
             consecutive_y_ties = 1;
         }
     }
 
+    vu += consecutive_y_ties * (consecutive_y_ties - 1) * (2 * consecutive_y_ties + 5);
+    v1_part_2 += consecutive_y_ties * (consecutive_y_ties - 1);
+
+    let consecutive_y_ties_i = consecutive_y_ties as isize;
+    v2_part_2 += consecutive_y_ties_i * (consecutive_y_ties_i - 1) * (consecutive_y_ties_i - 2);
+
     tied_y_pairs += sum(consecutive_y_ties - 1);
+
+    let v1 = (v1_part_1 * v1_part_2) as f64;
+    let v2 = (v2_part_1 * v2_part_2) as f64;
 
     // to prevent overflow on subtraction
     let num_pairs_f: f64 = ((n * (n - 1)) as f64) / 2.0; // sum(n - 1).as_();
@@ -198,12 +237,23 @@ where
     //           C-D = tot - xtie - ytie + ntie - 2 * dis
     let concordant_minus_discordant =
         num_pairs_f - tied_x_pairs_f - tied_y_pairs_f + tied_xy_pairs_f - swaps_f;
+
+    // non_tied_pairs_multiplied = ((n0 - n1) * (n0 - n2)).sqrt()
     let non_tied_pairs_multiplied = (num_pairs_f - tied_x_pairs_f) * (num_pairs_f - tied_y_pairs_f);
 
-    let tau = concordant_minus_discordant / non_tied_pairs_multiplied.sqrt();
+    let tau_b = concordant_minus_discordant / non_tied_pairs_multiplied.sqrt();
 
-    // limit range to fix computational errors
-    Ok(tau.max(-1.0).min(1.0))
+    // Significance
+    let v0 = (n * (n - 1)) * (2 * n + 5);
+    let n_f = n as f64;
+            
+    let var_s = (v0 - vt - vu) as f64 / 18.0 + v1 / (2.0 * n_f * (n_f - 1.0)) + v2 / (9.0 * n_f * (n_f - 1.0) * (n_f - 2.0));
+
+    let s = tau_b * non_tied_pairs_multiplied.sqrt();
+    let z = s / var_s.sqrt();
+
+    // Limit range to fix computational errors
+    Ok((tau_b.max(-1.0).min(1.0), z))
 }
 
 /// Calculate statistical significance: Z.
@@ -219,7 +269,7 @@ pub fn significance(tau: f64, n: usize) -> f64 {
 
 #[inline]
 fn sum(n: usize) -> usize {
-    n * (n + 1usize) / 2usize
+    n * (n + 1 as usize) / 2 as usize
 }
 
 #[cfg(test)]
@@ -238,11 +288,12 @@ mod tests {
             0.0, 0.0, 0.0, 0.0, 0.0,
         ];
 
-        let tau = tau_b_with_comparator(&x, &y, |a: &f64, b: &f64| {
+        let (tau_b, z) = tau_b_with_comparator(&x, &y, |a: &f64, b: &f64| {
             a.partial_cmp(&b).unwrap_or(Ordering::Greater)
         }).unwrap();
 
-        approx::assert_abs_diff_eq!(tau, -0.3762015410475098);
+        approx::assert_abs_diff_eq!(tau_b, -0.3762015410475098);
+        approx::assert_abs_diff_eq!(z, -2.09764910068664);
     }
 
     #[test]
@@ -251,25 +302,29 @@ mod tests {
 
         let x = &[1.0, 1.0, 2.0, 2.0, 3.0, 3.0];
         let y = &[1.0, 2.0, 2.0, 3.0, 3.0, 4.0];
-        let res = tau_b_with_comparator(&x[..], &y[..], comparator).unwrap();
-        approx::assert_abs_diff_eq!(res, 0.8006407690254358);
+        let (tau_b, z) = tau_b_with_comparator(&x[..], &y[..], comparator).unwrap();
+        approx::assert_abs_diff_eq!(tau_b, 0.8006407690254358);
+        approx::assert_abs_diff_eq!(z, 2.0526, epsilon = 0.0001);
 
         let x = &[12.0, 2.0, 1.0, 12.0, 2.0];
         let y = &[1.0, 4.0, 7.0, 1.0, 0.0];
-        let res = tau_b_with_comparator(&x[..], &y[..], comparator).unwrap();
-        approx::assert_abs_diff_eq!(res, -0.4714045207910316);
+        let (tau_b, z) = tau_b_with_comparator(&x[..], &y[..], comparator).unwrap();
+        approx::assert_abs_diff_eq!(tau_b, -0.4714045207910316);
+        approx::assert_abs_diff_eq!(z, -1.0742, epsilon = 0.0001);
     }
 
     #[test]
     fn simple_correlated_data() {
-        let res = tau_b(&[1, 2, 3], &[3, 4, 5]).unwrap();
-        assert_eq!(res, 1.0);
+        let (tau_b, z) = tau_b(&[1, 2, 3], &[3, 4, 5]).unwrap();
+        assert_eq!(tau_b, 1.0);
+        approx::assert_abs_diff_eq!(z, 1.5666989036012806);
     }
 
     #[test]
     fn simple_correlated_reversed() {
-        let res = tau_b(&[1, 2, 3], &[5, 4, 3]).unwrap();
-        assert_eq!(res, -1.0);
+        let (tau_b, z) = tau_b(&[1, 2, 3], &[5, 4, 3]).unwrap();
+        assert_eq!(tau_b, -1.0);
+        approx::assert_abs_diff_eq!(z, -1.5666989036012806);
     }
 
     #[test]
@@ -279,13 +334,14 @@ mod tests {
 
         // 6 pairs: (A,B) (A,C) (A,D) (B,C) (B,D) (C,D)
         // (B,C) is discordant, the other 5 are concordant
-        let expected = (5.0 - 1.0) / 6.0;
+        let expected_tau_b = (5.0 - 1.0) / 6.0;
+        let expected_z = 1.3587324409735149;
 
         assert_eq!(
             tau_b_with_comparator(x, y, |a: &f64, b: &f64| a
                 .partial_cmp(&b)
                 .unwrap_or(Ordering::Greater)),
-            Ok(expected)
+            Ok((expected_tau_b, expected_z))
         );
     }
 
@@ -301,7 +357,7 @@ mod tests {
             tau_b_with_comparator(&x, &y, |a: &f64, b: &f64| a
                 .partial_cmp(&b)
                 .unwrap_or(Ordering::Greater)),
-            Ok(0.0)
+            Ok((0.0, 0.0))
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,29 +119,14 @@ where
                 consecutive_xy_ties = 1;
             }
         } else {
-            // TODO: refactor
-            vt += consecutive_x_ties * (consecutive_x_ties - 1) * (2 * consecutive_x_ties + 5);
-            v1_part_1 += consecutive_x_ties * (consecutive_x_ties - 1);
-
-            let consecutive_x_ties_i = consecutive_x_ties as isize;
-            v2_part_1 += consecutive_x_ties_i * (consecutive_x_ties_i - 1) * (consecutive_x_ties_i - 2);
-
-            tied_x_pairs += sum(consecutive_x_ties - 1);
+            update_x_group(&mut vt, &mut tied_x_pairs, &mut tied_xy_pairs, &mut v1_part_1, &mut v2_part_1, consecutive_x_ties, consecutive_xy_ties);
             consecutive_x_ties = 1;
-            tied_xy_pairs += sum(consecutive_xy_ties - 1);
             consecutive_xy_ties = 1;
 
         }
     }
 
-    vt += consecutive_x_ties * (consecutive_x_ties - 1) * (2 * consecutive_x_ties + 5);
-    v1_part_1 += consecutive_x_ties * (consecutive_x_ties - 1);
-
-    let consecutive_x_ties_i = consecutive_x_ties as isize;
-    v2_part_1 += consecutive_x_ties_i * (consecutive_x_ties_i - 1) * (consecutive_x_ties_i - 2);
-
-    tied_x_pairs += sum(consecutive_x_ties - 1);
-    tied_xy_pairs += sum(consecutive_xy_ties - 1);
+    update_x_group(&mut vt, &mut tied_x_pairs, &mut tied_xy_pairs, &mut v1_part_1, &mut v2_part_1, consecutive_x_ties, consecutive_xy_ties);
 
     let mut swaps = 0usize;
     let mut pairs_dest: Vec<(T, T)> = vec![(Default::default(), Default::default()); n];
@@ -197,30 +182,18 @@ where
         if curr.1 == prev.1 {
             consecutive_y_ties += 1;
         } else {
-            // TODO: refactor
-            vu += consecutive_y_ties * (consecutive_y_ties - 1) * (2 * consecutive_y_ties + 5);
-            v1_part_2 += consecutive_y_ties * (consecutive_y_ties - 1);
-
-            let consecutive_y_ties_i = consecutive_y_ties as isize;
-            v2_part_2 += consecutive_y_ties_i * (consecutive_y_ties_i - 1) * (consecutive_y_ties_i - 2);
-            
-            tied_y_pairs += sum(consecutive_y_ties - 1);
+            update_y_group(&mut vu, &mut tied_y_pairs, &mut v1_part_2, &mut v2_part_2, consecutive_y_ties);
             consecutive_y_ties = 1;
         }
     }
 
-    vu += consecutive_y_ties * (consecutive_y_ties - 1) * (2 * consecutive_y_ties + 5);
-    v1_part_2 += consecutive_y_ties * (consecutive_y_ties - 1);
+    update_y_group(&mut vu, &mut tied_y_pairs, &mut v1_part_2, &mut v2_part_2, consecutive_y_ties);
 
-    let consecutive_y_ties_i = consecutive_y_ties as isize;
-    v2_part_2 += consecutive_y_ties_i * (consecutive_y_ties_i - 1) * (consecutive_y_ties_i - 2);
-
-    tied_y_pairs += sum(consecutive_y_ties - 1);
-
+    // Generates T1 and T2 for significance
     let v1 = (v1_part_1 * v1_part_2) as f64;
     let v2 = (v2_part_1 * v2_part_2) as f64;
 
-    // to prevent overflow on subtraction
+    // Prevents overflow on subtraction
     let num_pairs_f: f64 = ((n * (n - 1)) as f64) / 2.0; // sum(n - 1).as_();
     let tied_x_pairs_f: f64 = tied_x_pairs as f64;
     let tied_y_pairs_f: f64 = tied_y_pairs as f64;
@@ -255,6 +228,29 @@ where
 #[inline]
 fn sum(n: usize) -> usize {
     n * (n + 1 as usize) / 2 as usize
+}
+
+/// Updated vt, v1_part_1, v2_part_1, tied_x_pairs, tied_xy_pairs variables with current tied group in X
+fn update_x_group(vt: &mut usize, tied_x_pairs: &mut usize, tied_xy_pairs: &mut usize, v1_part_1: &mut usize, v2_part_1: & mut isize, consecutive_x_ties: usize, consecutive_xy_ties: usize) {
+    *vt += consecutive_x_ties * (consecutive_x_ties - 1) * (2 * consecutive_x_ties + 5);
+    *v1_part_1 += consecutive_x_ties * (consecutive_x_ties - 1);
+
+    let consecutive_x_ties_i = consecutive_x_ties as isize;
+    *v2_part_1 += consecutive_x_ties_i * (consecutive_x_ties_i - 1) * (consecutive_x_ties_i - 2);
+
+    *tied_x_pairs += sum(consecutive_x_ties - 1);
+    *tied_xy_pairs += sum(consecutive_xy_ties - 1);
+}
+
+/// Updated vu, tied_y_pairs, v1_part_2 and v2_part_2 variables with current tied group in Y
+fn update_y_group(vu: &mut usize, tied_y_pairs: &mut usize, v1_part_2: &mut usize, v2_part_2: & mut isize, consecutive_y_ties: usize) {
+    *vu += consecutive_y_ties * (consecutive_y_ties - 1) * (2 * consecutive_y_ties + 5);
+    *v1_part_2 += consecutive_y_ties * (consecutive_y_ties - 1);
+
+    let consecutive_y_ties_i = consecutive_y_ties as isize;
+    *v2_part_2 += consecutive_y_ties_i * (consecutive_y_ties_i - 1) * (consecutive_y_ties_i - 2);
+    
+    *tied_y_pairs += sum(consecutive_y_ties - 1);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This Pull Request fixes #2. List of changes:

+ Fixed bug. Now it computes Zb which is the correct one for Tau b.
+ Added tests for significance value
+ Remove significance function (significance computation needs data which is available only on `tau_b` method, so making computing it in a different function is not possible)
+ Changed examples in `lib.rs` to take into consideration the new significance value returned in `tau_b` and `tau_b_with_comparator`. Added reference to R [cor.test](https://github.com/SurajGupta/r-source/blob/master/src/library/stats/R/cor.test.R) function which is the one we based to fix the problem.
+ Some refactoring:
  + Changed `pairs` creation to a `collect()` to prevent a for loop
  + Refactored duplicated code

Maybe you want to add better examples than the ones I've quickly added, but the important stuff is done :D
