### PR TITLE
Use unstable sort for performance gain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kendalls"
 description = "Kendall's tau rank correlation"
-version = "0.2.2"
+version = "0.2.3"
 authors = [
 	"zolkko <zolkko@gmail.com>",
 	"Genaro Camele <genarocamele@gmail.com>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ where
 
     let mut pairs: Vec<(T, T)> = x.iter().cloned().zip(y.iter().cloned()).collect();
 
-    pairs.sort_by(|pair1, pair2| {
+    pairs.sort_unstable_by(|pair1, pair2| {
         let res = comparator(&pair1.0, &pair2.0);
         if res == Ordering::Equal {
             comparator(&pair1.1, &pair2.1)


### PR DESCRIPTION
[Sort_by](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.sort) uses stable sort, but it is generally recommended to use an unstable sort because it is often faster. Unstable sort uses Rust's ipnsort which is among the fastest sorting algorithms:
https://github.com/Voultapher/sort-research-rs/blob/main/writeup/intel_avx512/text.md

I tested this using criterion benchmark with the following results. We see roughly 15% improvement when N = 1000 and 28% for N = 10_000. 
![image](https://github.com/user-attachments/assets/c78e9167-4481-46b1-8cc2-93358dc5292d)

Results should not change whether we use stable or unstable sort since we sort on both X and Y. All unit tests still pass.

benches/my_benchmark.rs
```rust
extern crate criterion;
extern crate kendalls;
extern crate rand;
extern crate rand_distr;
use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
use kendalls::tau_b_with_comparator;
use rand::prelude::*;
use rand_distr::StandardNormal;
use std::time::Duration;

fn generate_data(len: usize) -> (Vec<f64>, Vec<f64>) {
    let mut rng = rand::rng();
    let x: Vec<f64> = (0..len).map(|_| StandardNormal.sample(&mut rng)).collect();

    let y: Vec<f64> = (0..len).map(|_| StandardNormal.sample(&mut rng)).collect();
    (x, y)
}

fn criterion_benchmark(c: &mut Criterion) {
    let mut group = c.benchmark_group("kendalls");
    group.measurement_time(Duration::from_secs(10));
    group.warm_up_time(Duration::from_secs(3));

    for n in [100, 1000, 10_000] {
        let (x, y) = generate_data(n);
        group.bench_with_input(BenchmarkId::new("taub", n), &n, |b, &n| {
            b.iter(|| {
                tau_b_with_comparator(
                    black_box(&x),
                    black_box(&y),
                    black_box(|a: &f64, b: &f64| {
                        a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Greater)
                    }),
                )
            });
        });
    }
    group.finish();
}

criterion_group!(benches, criterion_benchmark);
criterion_main!(benches);

```